### PR TITLE
ci: update github actions apps version to V3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies


### PR DESCRIPTION
All these github actions apps are now to V3, cf.:
- [actions/checkout](https://github.com/actions/checkout/releases)
- [actions/setup-node](https://github.com/actions/setup-node/releases/tag/v3.0.0)